### PR TITLE
Remove lm_kibana_enabled to ensure Kibana is always installed

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -88,7 +88,6 @@ lm_init_volumes: True
 #lm_theme_directory: directory which includes theme.tar file
 
 # Enable/disable optional elements of LM
-lm_kibana_enabled: True
 lm_kafdrop_enabled: False
 lm_nginx_ingress_enabled: True
 lm_filebeat_enabled: True

--- a/templates/base_values.yml
+++ b/templates/base_values.yml
@@ -28,11 +28,7 @@ filebeat:
 {% endif %}
 
 kibana:
-{% if lm_kibana_enabled|default(False)|bool == True %}
   enabled: true
-{% else %}
-  enabled: false
-{% endif %}
   ingress:
     enabled: true
     hosts:


### PR DESCRIPTION
This change should be approved along with [lm-allinone pull request](https://github.com/accanto-systems/lm-allinone/pull/7). Both pull requests are intended to go with automatically [enabled logging dashboard for lm-allinone](https://github.com/accanto-systems/lm-allinone/commit/9290a27365d8c75e5798c9859c371b9a7e3ea6cd) as without Kibana the logging dashboard link is invalid